### PR TITLE
POC1: Delay deletion of __name__ label (__deleted__name__ label) 

### DIFF
--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -357,8 +357,8 @@ func (ls Labels) DropMetricName() Labels {
 	return ls
 }
 
-// DropMetricDeleteName returns Labels with "__deleted__name__" removed.
-func (ls Labels) DropMetricDeleteName() Labels {
+// DropMetricDeletedName returns Labels with "__deleted__name__" removed.
+func (ls Labels) DropMetricDeletedName() Labels {
 	for i, l := range ls {
 		if l.Name == DeletedMetricName {
 			if i == 0 { // Make common case fast with no allocations.
@@ -372,18 +372,8 @@ func (ls Labels) DropMetricDeleteName() Labels {
 	return ls
 }
 
-// RestoreMetricName returns Labels with restored "__name__" label from "__deleted__name__".
-func (ls Labels) RestoreMetricName() Labels {
-	for i, l := range ls {
-		if l.Name == DeletedMetricName {
-			ls[i].Name = MetricName
-		}
-	}
-	return ls
-}
-
-// FlagMetricNameForDeletion returns Labels with "__name__" flagged for deletion.
-func (ls Labels) FlagMetricNameForDeletion() Labels {
+// MarkMetricNameForDeletion returns Labels with "__name__" marked for deletion.
+func (ls Labels) MarkMetricNameForDeletion() Labels {
 	for i, l := range ls {
 		if l.Name == MetricName {
 			ls[i].Name = DeletedMetricName

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -58,7 +58,7 @@ func (ls Labels) MatchLabels(on bool, names ...string) Labels {
 	}
 
 	for _, v := range ls {
-		if _, ok := nameSet[v.Name]; on == ok && (on || v.Name != MetricName) {
+		if _, ok := nameSet[v.Name]; on == ok && (on || (v.Name != MetricName) && v.Name != DeletedMetricName) {
 			matchedLabels = append(matchedLabels, v)
 		}
 	}
@@ -126,7 +126,7 @@ func (ls Labels) HashWithoutLabels(b []byte, names ...string) (uint64, []byte) {
 		for j < len(names) && names[j] < ls[i].Name {
 			j++
 		}
-		if ls[i].Name == MetricName || (j < len(names) && ls[i].Name == names[j]) {
+		if ls[i].Name == MetricName || ls[i].Name == DeletedMetricName || (j < len(names) && ls[i].Name == names[j]) {
 			continue
 		}
 		b = append(b, ls[i].Name...)
@@ -360,7 +360,7 @@ func (ls Labels) DropMetricName() Labels {
 // DropMetricDeleteName returns Labels with "__deleted__name__" removed.
 func (ls Labels) DropMetricDeleteName() Labels {
 	for i, l := range ls {
-		if l.Name == "__deleted"+MetricName {
+		if l.Name == DeletedMetricName {
 			if i == 0 { // Make common case fast with no allocations.
 				return ls[1:]
 			}
@@ -375,7 +375,7 @@ func (ls Labels) DropMetricDeleteName() Labels {
 // RestoreMetricName returns Labels with restored "__name__" label from "__deleted__name__".
 func (ls Labels) RestoreMetricName() Labels {
 	for i, l := range ls {
-		if l.Name == "__deleted"+MetricName {
+		if l.Name == DeletedMetricName {
 			ls[i].Name = MetricName
 		}
 	}
@@ -386,7 +386,7 @@ func (ls Labels) RestoreMetricName() Labels {
 func (ls Labels) FlagMetricNameForDeletion() Labels {
 	for i, l := range ls {
 		if l.Name == MetricName {
-			ls[i].Name = "__deleted" + ls[i].Name
+			ls[i].Name = DeletedMetricName
 		}
 	}
 	return ls

--- a/model/labels/labels.go
+++ b/model/labels/labels.go
@@ -357,10 +357,10 @@ func (ls Labels) DropMetricName() Labels {
 	return ls
 }
 
-// DropMetricDeleteName returns Labels with "__delete__name__" removed.
+// DropMetricDeleteName returns Labels with "__deleted__name__" removed.
 func (ls Labels) DropMetricDeleteName() Labels {
 	for i, l := range ls {
-		if l.Name == "__delete"+MetricName {
+		if l.Name == "__deleted"+MetricName {
 			if i == 0 { // Make common case fast with no allocations.
 				return ls[1:]
 			}
@@ -372,10 +372,10 @@ func (ls Labels) DropMetricDeleteName() Labels {
 	return ls
 }
 
-// RestoreMetricName returns Labels with restored "__name__" label from "__delete__name__".
+// RestoreMetricName returns Labels with restored "__name__" label from "__deleted__name__".
 func (ls Labels) RestoreMetricName() Labels {
 	for i, l := range ls {
-		if l.Name == "__delete"+MetricName {
+		if l.Name == "__deleted"+MetricName {
 			ls[i].Name = MetricName
 		}
 	}
@@ -386,7 +386,7 @@ func (ls Labels) RestoreMetricName() Labels {
 func (ls Labels) FlagMetricNameForDeletion() Labels {
 	for i, l := range ls {
 		if l.Name == MetricName {
-			ls[i].Name = "__delete" + ls[i].Name
+			ls[i].Name = "__deleted" + ls[i].Name
 		}
 	}
 	return ls

--- a/model/labels/labels_common.go
+++ b/model/labels/labels_common.go
@@ -24,10 +24,11 @@ import (
 )
 
 const (
-	MetricName   = "__name__"
-	AlertName    = "alertname"
-	BucketLabel  = "le"
-	InstanceName = "instance"
+	MetricName        = "__name__"
+	DeletedMetricName = "__deleted__name__"
+	AlertName         = "alertname"
+	BucketLabel       = "le"
+	InstanceName      = "instance"
 
 	labelSep = '\xfe'
 )

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1075,12 +1075,19 @@ func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, ws annotations.Anno
 	v, ws = ev.eval(expr)
 
 	if v.Type() == parser.ValueTypeMatrix {
-		// test label_replace(count_over_time({__name__!=""}[1m]), "name_label", "$1", "__name__", "(.+)")
 		mat := v.(Matrix)
 		for i := range mat {
 			mat[i].Metric = mat[i].Metric.DropMetricDeleteName()
 		}
 		if mat.ContainsSameLabelset() {
+			ev.errorf("vector cannot contain metrics with the same labelset")
+		}
+	} else if v.Type() == parser.ValueTypeVector {
+		vec := v.(Vector)
+		for i := range vec {
+			vec[i].Metric = vec[i].Metric.DropMetricDeleteName()
+		}
+		if vec.ContainsSameLabelset() {
 			ev.errorf("vector cannot contain metrics with the same labelset")
 		}
 	}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -2580,7 +2580,7 @@ func signatureFunc(on bool, b []byte, names ...string) func(labels.Labels) strin
 			return string(lset.BytesWithLabels(b, names...))
 		}
 	}
-	names = append([]string{labels.MetricName}, names...)
+	names = append([]string{labels.MetricName, labels.DeletedMetricName}, names...)
 	slices.Sort(names)
 	return func(lset labels.Labels) string {
 		return string(lset.BytesWithoutLabels(b, names...))

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1080,6 +1080,9 @@ func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, ws annotations.Anno
 		for i := range mat {
 			mat[i].Metric = mat[i].Metric.DropMetricDeleteName()
 		}
+		if mat.ContainsSameLabelset() {
+			ev.errorf("vector cannot contain metrics with the same labelset")
+		}
 	}
 	return v, ws, nil
 }

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1077,7 +1077,7 @@ func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, ws annotations.Anno
 	if v.Type() == parser.ValueTypeMatrix {
 		mat := v.(Matrix)
 		for i := range mat {
-			mat[i].Metric = mat[i].Metric.DropMetricDeleteName()
+			mat[i].Metric = mat[i].Metric.DropMetricDeletedName()
 		}
 		if mat.ContainsSameLabelset() {
 			ev.errorf("vector cannot contain metrics with the same labelset")
@@ -1085,7 +1085,7 @@ func (ev *evaluator) Eval(expr parser.Expr) (v parser.Value, ws annotations.Anno
 	} else if v.Type() == parser.ValueTypeVector {
 		vec := v.(Vector)
 		for i := range vec {
-			vec[i].Metric = vec[i].Metric.DropMetricDeleteName()
+			vec[i].Metric = vec[i].Metric.DropMetricDeletedName()
 		}
 		if vec.ContainsSameLabelset() {
 			ev.errorf("vector cannot contain metrics with the same labelset")
@@ -1633,7 +1633,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 			// vector functions, the only change needed is to drop the
 			// metric name in the output.
 			if e.Func.Name != "last_over_time" {
-				metric = metric.FlagMetricNameForDeletion()
+				metric = metric.MarkMetricNameForDeletion()
 			}
 			ss := Series{
 				Metric: metric,
@@ -1771,7 +1771,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 		mat := val.(Matrix)
 		if e.Op == parser.SUB {
 			for i := range mat {
-				mat[i].Metric = mat[i].Metric.FlagMetricNameForDeletion()
+				mat[i].Metric = mat[i].Metric.MarkMetricNameForDeletion()
 				for j := range mat[i].Floats {
 					mat[i].Floats[j].F = -mat[i].Floats[j].F
 				}
@@ -2548,7 +2548,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		}
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
 		if returnBool {
-			metric = metric.FlagMetricNameForDeletion()
+			metric = metric.MarkMetricNameForDeletion()
 		}
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
@@ -2674,7 +2674,7 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 			lhsSample.F = float
 			lhsSample.H = histogram
 			if shouldDropMetricName(op) || returnBool {
-				lhsSample.Metric = lhsSample.Metric.FlagMetricNameForDeletion()
+				lhsSample.Metric = lhsSample.Metric.MarkMetricNameForDeletion()
 			}
 			enh.Out = append(enh.Out, lhsSample)
 		}

--- a/promql/engine.go
+++ b/promql/engine.go
@@ -1764,7 +1764,7 @@ func (ev *evaluator) eval(expr parser.Expr) (parser.Value, annotations.Annotatio
 		mat := val.(Matrix)
 		if e.Op == parser.SUB {
 			for i := range mat {
-				mat[i].Metric = mat[i].Metric.DropMetricName()
+				mat[i].Metric = mat[i].Metric.FlagMetricNameForDeletion()
 				for j := range mat[i].Floats {
 					mat[i].Floats[j].F = -mat[i].Floats[j].F
 				}
@@ -2541,7 +2541,7 @@ func (ev *evaluator) VectorBinop(op parser.ItemType, lhs, rhs Vector, matching *
 		}
 		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
 		if returnBool {
-			metric = metric.DropMetricName()
+			metric = metric.FlagMetricNameForDeletion()
 		}
 		insertedSigs, exists := matchedSigs[sig]
 		if matching.Card == parser.CardOneToOne {
@@ -2667,7 +2667,7 @@ func (ev *evaluator) VectorscalarBinop(op parser.ItemType, lhs Vector, rhs Scala
 			lhsSample.F = float
 			lhsSample.H = histogram
 			if shouldDropMetricName(op) || returnBool {
-				lhsSample.Metric = lhsSample.Metric.DropMetricName()
+				lhsSample.Metric = lhsSample.Metric.FlagMetricNameForDeletion()
 			}
 			enh.Out = append(enh.Out, lhsSample)
 		}

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3149,7 +3149,7 @@ func TestDropMetricName(t *testing.T) {
 			ts:          baseT,
 			expectedErr: "vector cannot contain metrics with the same labelset",
 		},
-		"allows relabeling __name__ via label_replace": {
+		"allows relabeling using __name__ via label_replace": {
 			expr: "label_replace(count_over_time({__name__!=\"\"}[1m]), \"original_name\", \"$1\", \"__name__\", \"(.+)\")",
 			ts:   baseT,
 			expected: promql.Vector{
@@ -3165,19 +3165,51 @@ func TestDropMetricName(t *testing.T) {
 				},
 			},
 		},
-		"allows preserving __name__ via label_replace": {
-			expr: "label_replace(count_over_time({__name__!=\"\"}[1m]), \"__name__\", \"count_over_time_$1\", \"__name__\", \"(.+)\")",
+		"allows relabeling using __name__ via label_join": {
+			expr: "label_join(count_over_time({__name__!=\"\"}[1m]), \"original_name\", \"-\", \"__name__\", \"env\")",
 			ts:   baseT,
 			expected: promql.Vector{
 				promql.Sample{
 					F:      1,
 					T:      0,
-					Metric: labels.FromStrings("__name__", "count_over_time_some_metric", "env", "1"),
+					Metric: labels.FromStrings("original_name", "some_metric-1", "env", "1"),
 				},
 				promql.Sample{
 					F:      1,
 					T:      0,
-					Metric: labels.FromStrings("__name__", "count_over_time_some_other_metric", "env", "1"),
+					Metric: labels.FromStrings("original_name", "some_other_metric-1", "env", "1"),
+				},
+			},
+		},
+		"allows preserving __name__ via label_replace": {
+			expr: "label_replace(count_over_time({__name__!=\"\"}[1m]), \"__name__\", \"$1\", \"__name__\", \"(.+)\")",
+			ts:   baseT,
+			expected: promql.Vector{
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_metric", "env", "1"),
+				},
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_other_metric", "env", "1"),
+				},
+			},
+		},
+		"allows preserving __name__ via label_join": {
+			expr: "label_join(count_over_time({__name__!=\"\"}[1m]), \"__name__\", \"-\", \"__name__\", \"env\")",
+			ts:   baseT,
+			expected: promql.Vector{
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_metric-1", "env", "1"),
+				},
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_other_metric-1", "env", "1"),
 				},
 			},
 		},

--- a/promql/engine_test.go
+++ b/promql/engine_test.go
@@ -3096,6 +3096,110 @@ func TestInstantQueryWithRangeVectorSelector(t *testing.T) {
 	}
 }
 
+func TestDropMetricName(t *testing.T) {
+	engine := newTestEngine()
+
+	baseT := timestamp.Time(0)
+	storage := promqltest.LoadedStorage(t, `
+		load 1m
+			some_metric{env="1"} 1
+			some_other_metric{env="1"} 2
+	`)
+	t.Cleanup(func() { require.NoError(t, storage.Close()) })
+
+	testCases := map[string]struct {
+		expr        string
+		expected    promql.Vector
+		expectedErr string
+		ts          time.Time
+	}{
+		"does not drop __name__ for instant queries": {
+			expr: "{__name__!=\"\"}",
+			ts:   baseT,
+			expected: promql.Vector{
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_metric", "env", "1"),
+				},
+				promql.Sample{
+					F:      2,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "some_other_metric", "env", "1"),
+				},
+			},
+		},
+		"drops __name__ for functions": {
+			expr:        "count_over_time({__name__!=\"\"}[1m])",
+			ts:          baseT,
+			expectedErr: "vector cannot contain metrics with the same labelset",
+		},
+		"drops __name__ for unary expressions": {
+			expr:        "-{__name__!=\"\"}",
+			ts:          baseT,
+			expectedErr: "vector cannot contain metrics with the same labelset",
+		},
+		"drops __name__ for binary operations": {
+			expr:        "{__name__!=\"\"} + {__name__!=\"\"}",
+			ts:          baseT,
+			expectedErr: "vector cannot contain metrics with the same labelset",
+		},
+		"drops __name__ for vector-scalar binary operations": {
+			expr:        "{__name__!=\"\"} * 2",
+			ts:          baseT,
+			expectedErr: "vector cannot contain metrics with the same labelset",
+		},
+		"allows relabeling __name__ via label_replace": {
+			expr: "label_replace(count_over_time({__name__!=\"\"}[1m]), \"original_name\", \"$1\", \"__name__\", \"(.+)\")",
+			ts:   baseT,
+			expected: promql.Vector{
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("original_name", "some_metric", "env", "1"),
+				},
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("original_name", "some_other_metric", "env", "1"),
+				},
+			},
+		},
+		"allows preserving __name__ via label_replace": {
+			expr: "label_replace(count_over_time({__name__!=\"\"}[1m]), \"__name__\", \"count_over_time_$1\", \"__name__\", \"(.+)\")",
+			ts:   baseT,
+			expected: promql.Vector{
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "count_over_time_some_metric", "env", "1"),
+				},
+				promql.Sample{
+					F:      1,
+					T:      0,
+					Metric: labels.FromStrings("__name__", "count_over_time_some_other_metric", "env", "1"),
+				},
+			},
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			q, err := engine.NewInstantQuery(context.Background(), storage, nil, testCase.expr, testCase.ts)
+			require.NoError(t, err)
+			defer q.Close()
+
+			res := q.Exec(context.Background())
+			if testCase.expectedErr != "" {
+				require.Error(t, res.Err, testCase.expectedErr)
+			} else {
+				require.NoError(t, res.Err)
+				testutil.RequireEqual(t, testCase.expected, res.Value)
+			}
+		})
+	}
+}
+
 func TestNativeHistogram_Sum_Count_Add_AvgOperator(t *testing.T) {
 	// TODO(codesome): Integrate histograms into the PromQL testing framework
 	// and write more tests there.

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1386,6 +1386,9 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for i, el := range matrix {
+		if src == labels.MetricName {
+			matrix[i].Metric = matrix[i].Metric.RestoreMetricName()
+		}
 		srcVal := el.Metric.Get(src)
 		indexes := regex.FindStringSubmatchIndex(srcVal)
 		if indexes != nil { // Only replace when regexp matches.
@@ -1393,6 +1396,9 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 			lb.Reset(el.Metric)
 			lb.Set(dst, string(res))
 			matrix[i].Metric = lb.Labels()
+		}
+		if dst != labels.MetricName {
+			matrix[i].Metric = matrix[i].Metric.FlagMetricNameForDeletion()
 		}
 	}
 	if matrix.ContainsSameLabelset() {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1386,9 +1386,8 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for i, el := range matrix {
-		shouldRestoreName := el.Metric.Has(labels.DeletedMetricName)
-		if shouldRestoreName && src == labels.MetricName {
-			matrix[i].Metric = matrix[i].Metric.RestoreMetricName()
+		if src == labels.MetricName && el.Metric.Has(labels.DeletedMetricName) {
+			src = labels.DeletedMetricName
 		}
 		srcVal := el.Metric.Get(src)
 		indexes := regex.FindStringSubmatchIndex(srcVal)
@@ -1398,8 +1397,8 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 			lb.Set(dst, string(res))
 			matrix[i].Metric = lb.Labels()
 		}
-		if shouldRestoreName && dst != labels.MetricName {
-			matrix[i].Metric = matrix[i].Metric.FlagMetricNameForDeletion()
+		if dst != labels.MetricName && matrix[i].Metric.Has(labels.DeletedMetricName) {
+			matrix[i].Metric = matrix[i].Metric.DropMetricDeleteName()
 		}
 	}
 	if matrix.ContainsSameLabelset() {

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -458,7 +458,7 @@ func funcClamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	}
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      math.Max(min, math.Min(max, el.F)),
 		})
 	}
@@ -471,7 +471,7 @@ func funcClampMax(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	max := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      math.Min(max, el.F),
 		})
 	}
@@ -484,7 +484,7 @@ func funcClampMin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	min := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      math.Max(min, el.F),
 		})
 	}
@@ -506,7 +506,7 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	for _, el := range vec {
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      f,
 		})
 	}
@@ -838,7 +838,7 @@ func simpleFunc(vals []parser.Value, enh *EvalNodeHelper, f func(float64) float6
 	for _, el := range vals[0].(Vector) {
 		if el.H == nil { // Process only float samples.
 			enh.Out = append(enh.Out, Sample{
-				Metric: el.Metric.FlagMetricNameForDeletion(),
+				Metric: el.Metric.MarkMetricNameForDeletion(),
 				F:      f(el.F),
 			})
 		}
@@ -984,7 +984,7 @@ func funcTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHe
 	vec := vals[0].(Vector)
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      float64(el.T) / 1000,
 		})
 	}
@@ -1089,7 +1089,7 @@ func funcHistogramCount(vals []parser.Value, args parser.Expressions, enh *EvalN
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      sample.H.Count,
 		})
 	}
@@ -1106,7 +1106,7 @@ func funcHistogramSum(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      sample.H.Sum,
 		})
 	}
@@ -1123,7 +1123,7 @@ func funcHistogramAvg(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      sample.H.Sum / sample.H.Count,
 		})
 	}
@@ -1162,7 +1162,7 @@ func funcHistogramStdDev(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      math.Sqrt(variance),
 		})
 	}
@@ -1201,7 +1201,7 @@ func funcHistogramStdVar(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      variance,
 		})
 	}
@@ -1220,7 +1220,7 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      histogramFraction(lower, upper, sample.H),
 		})
 	}
@@ -1290,7 +1290,7 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 		}
 
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.FlagMetricNameForDeletion(),
+			Metric: sample.Metric.MarkMetricNameForDeletion(),
 			F:      histogramQuantile(q, sample.H),
 		})
 	}
@@ -1398,7 +1398,7 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 			matrix[i].Metric = lb.Labels()
 		}
 		if dst != labels.MetricName && matrix[i].Metric.Has(labels.DeletedMetricName) {
-			matrix[i].Metric = matrix[i].Metric.DropMetricDeleteName()
+			matrix[i].Metric = matrix[i].Metric.DropMetricDeletedName()
 		}
 	}
 	if matrix.ContainsSameLabelset() {
@@ -1459,7 +1459,7 @@ func (ev *evaluator) evalLabelJoin(args parser.Expressions) (parser.Value, annot
 		matrix[i].Metric = lb.Labels()
 
 		if dst != labels.MetricName && matrix[i].Metric.Has(labels.DeletedMetricName) {
-			matrix[i].Metric = matrix[i].Metric.DropMetricDeleteName()
+			matrix[i].Metric = matrix[i].Metric.DropMetricDeletedName()
 		}
 	}
 
@@ -1484,7 +1484,7 @@ func dateWrapper(vals []parser.Value, enh *EvalNodeHelper, f func(time.Time) flo
 	for _, el := range vals[0].(Vector) {
 		t := time.Unix(int64(el.F), 0).UTC()
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.FlagMetricNameForDeletion(),
+			Metric: el.Metric.MarkMetricNameForDeletion(),
 			F:      f(t),
 		})
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1447,12 +1447,20 @@ func (ev *evaluator) evalLabelJoin(args parser.Expressions) (parser.Value, annot
 
 	for i, el := range matrix {
 		for i, src := range srcLabels {
+			if src == labels.MetricName && el.Metric.Has(labels.DeletedMetricName) {
+				src = labels.DeletedMetricName
+			}
+
 			srcVals[i] = el.Metric.Get(src)
 		}
 		strval := strings.Join(srcVals, sep)
 		lb.Reset(el.Metric)
 		lb.Set(dst, strval)
 		matrix[i].Metric = lb.Labels()
+
+		if dst != labels.MetricName && matrix[i].Metric.Has(labels.DeletedMetricName) {
+			matrix[i].Metric = matrix[i].Metric.DropMetricDeleteName()
+		}
 	}
 
 	return matrix, ws

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1386,7 +1386,8 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 	lb := labels.NewBuilder(labels.EmptyLabels())
 
 	for i, el := range matrix {
-		if src == labels.MetricName {
+		shouldRestoreName := el.Metric.Has(labels.DeletedMetricName)
+		if shouldRestoreName && src == labels.MetricName {
 			matrix[i].Metric = matrix[i].Metric.RestoreMetricName()
 		}
 		srcVal := el.Metric.Get(src)
@@ -1397,7 +1398,7 @@ func (ev *evaluator) evalLabelReplace(args parser.Expressions) (parser.Value, an
 			lb.Set(dst, string(res))
 			matrix[i].Metric = lb.Labels()
 		}
-		if dst != labels.MetricName {
+		if shouldRestoreName && dst != labels.MetricName {
 			matrix[i].Metric = matrix[i].Metric.FlagMetricNameForDeletion()
 		}
 	}

--- a/promql/functions.go
+++ b/promql/functions.go
@@ -458,7 +458,7 @@ func funcClamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	}
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      math.Max(min, math.Min(max, el.F)),
 		})
 	}
@@ -471,7 +471,7 @@ func funcClampMax(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	max := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      math.Min(max, el.F),
 		})
 	}
@@ -484,7 +484,7 @@ func funcClampMin(vals []parser.Value, args parser.Expressions, enh *EvalNodeHel
 	min := vals[1].(Vector)[0].F
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      math.Max(min, el.F),
 		})
 	}
@@ -506,7 +506,7 @@ func funcRound(vals []parser.Value, args parser.Expressions, enh *EvalNodeHelper
 	for _, el := range vec {
 		f := math.Floor(el.F*toNearestInverse+0.5) / toNearestInverse
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      f,
 		})
 	}
@@ -838,7 +838,7 @@ func simpleFunc(vals []parser.Value, enh *EvalNodeHelper, f func(float64) float6
 	for _, el := range vals[0].(Vector) {
 		if el.H == nil { // Process only float samples.
 			enh.Out = append(enh.Out, Sample{
-				Metric: el.Metric.DropMetricName(),
+				Metric: el.Metric.FlagMetricNameForDeletion(),
 				F:      f(el.F),
 			})
 		}
@@ -984,7 +984,7 @@ func funcTimestamp(vals []parser.Value, args parser.Expressions, enh *EvalNodeHe
 	vec := vals[0].(Vector)
 	for _, el := range vec {
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      float64(el.T) / 1000,
 		})
 	}
@@ -1089,7 +1089,7 @@ func funcHistogramCount(vals []parser.Value, args parser.Expressions, enh *EvalN
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      sample.H.Count,
 		})
 	}
@@ -1106,7 +1106,7 @@ func funcHistogramSum(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      sample.H.Sum,
 		})
 	}
@@ -1123,7 +1123,7 @@ func funcHistogramAvg(vals []parser.Value, args parser.Expressions, enh *EvalNod
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      sample.H.Sum / sample.H.Count,
 		})
 	}
@@ -1162,7 +1162,7 @@ func funcHistogramStdDev(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      math.Sqrt(variance),
 		})
 	}
@@ -1201,7 +1201,7 @@ func funcHistogramStdVar(vals []parser.Value, args parser.Expressions, enh *Eval
 		variance += cVariance
 		variance /= sample.H.Count
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      variance,
 		})
 	}
@@ -1220,7 +1220,7 @@ func funcHistogramFraction(vals []parser.Value, args parser.Expressions, enh *Ev
 			continue
 		}
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      histogramFraction(lower, upper, sample.H),
 		})
 	}
@@ -1290,7 +1290,7 @@ func funcHistogramQuantile(vals []parser.Value, args parser.Expressions, enh *Ev
 		}
 
 		enh.Out = append(enh.Out, Sample{
-			Metric: sample.Metric.DropMetricName(),
+			Metric: sample.Metric.FlagMetricNameForDeletion(),
 			F:      histogramQuantile(q, sample.H),
 		})
 	}
@@ -1476,7 +1476,7 @@ func dateWrapper(vals []parser.Value, enh *EvalNodeHelper, f func(time.Time) flo
 	for _, el := range vals[0].(Vector) {
 		t := time.Unix(int64(el.F), 0).UTC()
 		enh.Out = append(enh.Out, Sample{
-			Metric: el.Metric.DropMetricName(),
+			Metric: el.Metric.FlagMetricNameForDeletion(),
 			F:      f(t),
 		})
 	}


### PR DESCRIPTION
  - Delay dropping the  `__name__` label to the end of the query evaluation. This allows optionally preserving it via the `label_replace` and `label_join` functions, and helps prevent the dreaded "vector cannot contain metrics with the same labelset" error.
  - This implementation makes use of a special label (`__deleted__name__`) to automatically propagate the deletion of the `__name__` label.
    - The advantage of this implementation is that the name-dropping information is automatically propagated as it is carried along with the other labels, so there is less risk of "forgetting" to propagate it in certain places.
    - The downside is that it is not 100% transparent to the user; if a user defines a `__deleted__name__` label, weird things may happen (it may be overriden and/or deleted).
  -  The `label_replace` and `label_join` functions can still access the value of the `__name__` label, even if it has been previously marked for deletion. If  `__name__` is used as target label, it won't be dropped at the end of the query evaluation.
  - This code passes all existing tests with the standard implementation of `labels.Labels`. Other implementations have not been updated yet.
  - See https://github.com/jcreixell/prometheus/pull/2 for an alternative implementation using boolean flags in the `Series` and `Sample` structs, and manual propagation.
  - Fixes https://github.com/prometheus/prometheus/issues/11397

Example (this always fails, as `__name__` is being dropped by `count_over_time`):

```
count_over_time({__name__!=""}[1m])

=> Error executing query: vector cannot contain metrics with the same labelset
```

Before:

```
label_replace(count_over_time({__name__!=""}[1m]), "__name__", "rate_$1", "__name__", "(.+)")

=> Error executing query: vector cannot contain metrics with the same labelset
```

After:

```
label_replace(count_over_time({__name__!=""}[1m]), "__name__", "rate_$1", "__name__", "(.+)")

=> 
rate_go_gc_cycles_automatic_gc_cycles_total{instance="localhost:9090", job="prometheus"} 1
rate_go_gc_cycles_forced_gc_cycles_total{instance="localhost:9090", job="prometheus"} 1
...
```

